### PR TITLE
Replace hardcoded person share values with formulas in spreadsheet

### DIFF
--- a/src/bill/calculator.py
+++ b/src/bill/calculator.py
@@ -214,9 +214,15 @@ class Calculator:
 
         for item in self.items.items:
             row_data = [item.name, item.price]
+            split_count = self.get_split_count(item)
+            item_index = self.items.items.index(item)
+
             for person in self.persons:
-                share = self.get_person_share(item, person)
-                row_data.append(share if share else None)
+                if item_index in person.items:
+                    formula = f"=$B{current_row}/{split_count}"
+                    row_data.append(formula)
+                else:
+                    row_data.append(None)
             row_data.append(None)
             worksheet.append(row_data)
             current_row += 1

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -240,20 +240,20 @@ def test_spreadsheet(calculator, sample_persons):
 
     assert worksheet["A2"].value == "GL-Domaine Amido Cotes Du Rhone"
     assert worksheet["B2"].value == 13.00
-    assert worksheet["C2"].value == 6.50
+    assert worksheet["C2"].value == "=$B2/2"
     assert worksheet["D2"].value is None
-    assert worksheet["E2"].value == 6.50
+    assert worksheet["E2"].value == "=$B2/2"
 
     assert worksheet["A16"].value == "Shahi tukda"
     assert worksheet["B16"].value == 15.00
-    assert worksheet["C16"].value == 5.00
-    assert worksheet["D16"].value == 5.00
-    assert worksheet["E16"].value == 5.00
+    assert worksheet["C16"].value == "=$B16/3"
+    assert worksheet["D16"].value == "=$B16/3"
+    assert worksheet["E16"].value == "=$B16/3"
 
     assert worksheet["A17"].value == "Jus d Manguir"
     assert worksheet["B17"].value == 9.00
-    assert worksheet["C17"].value == 4.50
-    assert worksheet["D17"].value == 4.50
+    assert worksheet["C17"].value == "=$B17/2"
+    assert worksheet["D17"].value == "=$B17/2"
     assert worksheet["E17"].value is None
 
     subtotal_row = 18


### PR DESCRIPTION
Updates the spreadsheet to use formulas instead of hardcoded values for person shares, making calculations transparent and editable.

Changes:
- Modified get_shares_spreadsheet() to generate formulas for each person's share of items
- Formula format: =$B{row}/{split_count} (e.g., =$B2/2 for items split between 2 people)
- Uses get_split_count() to determine how many people share each item
- Updated test expectations to verify formulas instead of literal values
- Makes spreadsheet calculations visible and manually editable

Benefits:
- Users can see exactly how shares are calculated
- Formulas can be edited if needed
- Split counts are clearly visible in the formulas